### PR TITLE
Use ENV['ACCELA_ACCESS_TOKEN'] if present.

### DIFF
--- a/lib/accela/configuration.rb
+++ b/lib/accela/configuration.rb
@@ -22,9 +22,14 @@ module Accela
 
     attr_reader_safe :app_id, :app_secret, :agency, :environment
 
+    TokenFromEnv = Struct.new(:access_token)
     def self.token
-      raise InvalidTokenError.new("You do not have a token.") unless @token
-      @token
+      if access_token = ENV['ACCELA_ACCESS_TOKEN']
+        TokenFromEnv.new(access_token)
+      else
+        raise InvalidTokenError.new("You do not have a token.") unless @token
+        @token
+      end
     end
 
     def self.base_uri


### PR DESCRIPTION
The access token in ENV will always take precedence, so it should be
replaced before it expires.

To revert to the standard Token object, unset the environment variable
ACCELA_ACCESS_TOKEN.