### PR TITLE
Better error messages when Accela returns Data Validation Error

### DIFF
--- a/lib/accela/api/error_handler.rb
+++ b/lib/accela/api/error_handler.rb
@@ -3,7 +3,11 @@ module Accela
     attr_reader :response
 
     def self.handle(response)
-      new(response).handle
+      if response['status'] == 500 && response['result'].is_a?(Array)
+        new(response).handle_data_validation_error
+      else
+        new(response).handle
+      end
     end
 
     def initialize(response)
@@ -15,6 +19,10 @@ module Accela
         exception = error ? error.last : UnexpectedError
         raise exception, message
       end
+    end
+
+    def handle_data_validation_error
+      raise DataValidationError, response['result'][0]['message']
     end
 
     private

--- a/lib/accela/api/error_handler.rb
+++ b/lib/accela/api/error_handler.rb
@@ -3,10 +3,10 @@ module Accela
     attr_reader :response
 
     def self.handle(response)
-      if response['status'] == 500 && response['result'].is_a?(Array)
-        new(response).handle_data_validation_error
-      else
+      begin
         new(response).handle
+      rescue KeyError
+        new(response).handle_unexpected_error
       end
     end
 
@@ -21,8 +21,8 @@ module Accela
       end
     end
 
-    def handle_data_validation_error
-      raise DataValidationError, response['result'][0]['message']
+    def handle_unexpected_error
+      raise UnexpectedError, response['result'][0]['message']
     end
 
     private

--- a/lib/accela/version.rb
+++ b/lib/accela/version.rb
@@ -2,7 +2,7 @@ module Accela
   module Version
     Major = 0
     Minor = 0
-    Patch = 0
+    Patch = 2
 
     String = "#{Major}.#{Minor}.#{Patch}"
   end


### PR DESCRIPTION
The response from Accela is different when the error is a Data Validation Error.

Previous behaviour was to raise a `KeyError: code not found`.  Now, when this error is raised the error handler tries to parse the response differently.

If this fails, we're back to unhelpful errors: probably `undefined method [] for nil:NilClass`

---

Limitations:

* Probably suppresses additional error messages if there are multiple validation errors contained in the results array.
* As above, still has the potential to produce unhelpful error messages. 