### PR TITLE
Update accela gem spec

### DIFF
--- a/accela.gemspec
+++ b/accela.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.homepage       = 'https://developer.accela.com/'
   s.license        = 'MIT'
   s.add_dependency   'httparty', '~> 0.13'
-  s.add_dependency   'activesupport', '~> 3.2.19'
+  s.add_dependency   'activesupport', '>= 3.2.19'
 end


### PR DESCRIPTION
Require active-support greater than 3.2.19

This allows the gem to work with both rails 3 and 4